### PR TITLE
chore: remove TypedConfigBound and add 1.0.1 patch changeset

### DIFF
--- a/.changeset/patch-align-1-0-1.md
+++ b/.changeset/patch-align-1-0-1.md
@@ -1,0 +1,33 @@
+---
+"@config-bound/core": patch
+---
+
+Changelog and release alignment for 1.0.0 changes.
+
+**Breaking: `TypedConfigBound` removed**
+
+`TypedConfigBound<T>` has been removed. Use `ConfigBound<T>` directly — `ConfigBound` is now generic.
+
+```ts
+// Before
+import { TypedConfigBound } from '@config-bound/core';
+const config: TypedConfigBound<typeof schema> = await ConfigBound.createConfig(schema, options);
+
+// After
+import { ConfigBound } from '@config-bound/core';
+const config: ConfigBound<typeof schema> = await ConfigBound.createConfig(schema, options);
+```
+
+**Breaking: `ConfigBoundService.getTypedConfigBound()` renamed to `getConfigBound()`**
+
+Update any NestJS service call sites that used `getTypedConfigBound()`.
+
+**New: `@config-bound/core/schema` entry point**
+
+Schema builder functions (`configItem`, `configSection`, `configEnum`) and their types are now available from a dedicated entry point for better tree-shaking:
+
+```ts
+import { configItem, configSection, configEnum } from '@config-bound/core/schema';
+```
+
+They remain re-exported from `@config-bound/core` for backwards compatibility.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -57,7 +57,7 @@ jobs:
         run: pnpm run test
 
       - name: Security Scan
-        uses: anchore/scan-action@v7
+        uses: anchore/scan-action@v7.4.0
         with:
           path: "."
           fail-build: true
@@ -77,7 +77,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -93,10 +93,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -108,7 +108,7 @@ jobs:
 
       - name: Security Scan
         id: scan
-        uses: anchore/scan-action@v7
+        uses: anchore/scan-action@v7.4.0
         with:
           path: '.'
           fail-build: true

--- a/apps/docs/explanation/anatomy-of-configbound.md
+++ b/apps/docs/explanation/anatomy-of-configbound.md
@@ -93,7 +93,7 @@ An element is the unit of runtime behavior for a single configuration value.
 
 ## The ConfigBound instance
 
-`createConfig()` returns a `TypedConfigBound`, which wraps a `ConfigBound` and provides full TypeScript inference over the schema. The two main ways to read values are:
+`createConfig()` returns a `ConfigBound<T>`, which provides full TypeScript inference over the schema. The two main ways to read values are:
 
 - **`get(section, element)`** - returns the value or `undefined` if nothing is set and there is no default.
 - **`getOrThrow(section, element)`** - returns the value or throws if it is `undefined`.

--- a/apps/docs/how-to/schema-export.md
+++ b/apps/docs/how-to/schema-export.md
@@ -2,7 +2,7 @@
 description: Serialize your ConfigBound schema to JSON or YAML for use in documentation, CI, or tooling.
 ---
 
-# Export your configuration schema
+# Export your configuration schema <Badge type="tip" text="schema-export" />
 
 The config schema already contains everything needed to describe your
 configuration: structure, types, defaults, descriptions, and sensitivity flags.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -174,6 +174,7 @@
       "./src/bind/binds/envVar.ts",
       "./src/bind/binds/file.ts",
       "./src/bind/binds/static.ts",
+      "./src/utilities/configLoaderErrors.ts",
       "./src/utilities/errors.ts",
       "./src/utilities/logger.ts"
     ],

--- a/packages/core/src/configBound.ts
+++ b/packages/core/src/configBound.ts
@@ -85,12 +85,6 @@ export interface ConfigBoundCreateOptions {
 }
 
 /**
- * @deprecated Use {@link ConfigBound} directly. `ConfigBound` is now generic — replace
- * `TypedConfigBound<T>` with `ConfigBound<T>`. This alias will be removed in a future major version.
- */
-export type TypedConfigBound<T extends ConfigSchema> = ConfigBound<T>;
-
-/**
  * A ConfigBound is the top level object that contains all the {@link Section}s and {@link Bind}s.
  * It is used to retrieve the values of the {@link Element Elements} from its binds.
  *
@@ -505,7 +499,7 @@ export class ConfigBound<TSchema extends ConfigSchema = ConfigSchema> implements
    *
    * @param schema - Declarative configuration schema.
    * @param options - Optional name, binds, logger, and cache mode.
-   * @returns A fully initialized {@link TypedConfigBound} instance typed to the provided schema.
+   * @returns A fully initialized {@link ConfigBound} instance typed to the provided schema.
    * @example
    * ```typescript
    * const config = await ConfigBound.createConfig(

--- a/packages/nestjs/README.md
+++ b/packages/nestjs/README.md
@@ -184,7 +184,7 @@ The service provides full type-safe access to your configuration:
 - `addBind(bind: Bind)`: Add a new bind at runtime
 - `addSection(section: Section)`: Add a new section at runtime
 - `getSections()`: Get all configuration sections
-- `getTypedConfigBound()`: Get the underlying TypedConfigBound instance
+- `getConfigBound()`: Get the underlying ConfigBound instance
 
 **Properties:**
 


### PR DESCRIPTION
Removes `TypedConfigBound<T>` entirely and updates all references in docs and README to use `ConfigBound<T>` directly. Adds the 1.0.1 patch changeset with missing changelog entries from the 1.0.0 release (`getConfigBound()` rename, `core/schema` entry point).